### PR TITLE
refactor!: settle on single hashAlgo-hexHash fragment format

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,13 @@ is chosen.
 
 To verify downloads against known good digests, place a digest in the URL
 fragment.
-Supported fragment formats are `digestAlgo-hexDigest`, `digestAlgo=hexDigest`,
-or plain `hexDigest` alone (in which case the digest length is used to determine
-the digest algorithm).
+The fragment format to use is `digestAlgo-hexDigest`.
 
 For example:
 
 - `#sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9842`
-- `#sha512=9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043`
-- `#5d41402abc4b2a76b9719d911017c592` (MD-5 based on length)
+- `#sha512-9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043`
+- `#md5-5d41402abc4b2a76b9719d911017c592`)
 
 ## CI usage
 

--- a/wrun.go
+++ b/wrun.go
@@ -47,7 +47,7 @@ var (
 const (
 	cacheDirEnvVar            = "WRUN_CACHE_HOME"
 	verboseEnvVar             = "WRUN_VERBOSE"
-	cacheVersion              = "v1"
+	cacheVersion              = "v2"
 	cacheDirDigestPlaceholder = "_"
 )
 

--- a/wrun.go
+++ b/wrun.go
@@ -51,14 +51,6 @@ const (
 	cacheDirDigestPlaceholder = "_"
 )
 
-var hashesBySize = map[int]crypto.Hash{
-	crypto.MD5.Size():    crypto.MD5,
-	crypto.SHA1.Size():   crypto.SHA1,
-	crypto.SHA224.Size(): crypto.SHA224,
-	crypto.SHA256.Size(): crypto.SHA256,
-	crypto.SHA384.Size(): crypto.SHA384,
-	crypto.SHA512.Size(): crypto.SHA512,
-}
 var hashesByName = map[string]crypto.Hash{
 	hashName(crypto.MD4):       crypto.MD4,
 	hashName(crypto.MD5):       crypto.MD5,
@@ -77,39 +69,25 @@ func hashName(h crypto.Hash) string {
 	return hn
 }
 
-// prepareHash prepares a hash corresponding to the given digest string.
+// prepareHash prepares a hash corresponding to the given fragment string.
 // It returns the hash and the digest to check with it.
 // If s is empty, 0 is returned as the hash.
 func prepareHash(s string) (crypto.Hash, []byte, error) {
 	if s == "" {
 		return 0, []byte{}, nil
 	}
-	name, hexHash, found := strings.Cut(s, "-") // Docker Hub style, hash=hexDigest
-	if !found {
-		name, hexHash, found = strings.Cut(s, "=") // PyPI style, hash-hexDigest
-		if !found {
-			name = ""
-			hexHash = s
-		}
+	name, hexHash, found := strings.Cut(s, "-")
+	if name == "" || hexHash == "" || !found {
+		return 0, nil, fmt.Errorf("invalid fragment format, use hashAlgo-hexDigest")
 	}
-	var (
-		digest   []byte
-		hashType crypto.Hash
-	)
 	digest, err := hex.DecodeString(hexHash)
 	if err != nil {
 		return 0, nil, err
 	}
-	if name != "" {
-		hashType, found = hashesByName[strings.ToLower(name)]
-		if !found {
-			return 0, nil, fmt.Errorf("no supported hash with name %q", name)
-		}
-	} else {
-		hashType, found = hashesBySize[len(digest)]
-		if !found {
-			return 0, nil, fmt.Errorf("no supported hash with digest size %d", len(digest))
-		}
+	var hashType crypto.Hash
+	hashType, found = hashesByName[strings.ToLower(name)]
+	if !found {
+		return 0, nil, fmt.Errorf("no supported hash with name %q", name)
 	}
 	if !hashType.Available() {
 		return 0, nil, fmt.Errorf("hash %s not available", hashType)

--- a/wrun_test.go
+++ b/wrun_test.go
@@ -156,23 +156,11 @@ func Test_urlDir(t *testing.T) {
 			"example.com/path/to/file" + url.PathEscape("?foo=bar") + "/" + cacheDirDigestPlaceholder,
 		},
 		{
-			"https://example.com//path/to/file#2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-			"example.com/path/to/file/sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-		},
-		{
 			"https://example.com//path/to/file#sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 			"example.com/path/to/file/sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 		},
 		{
-			"https://example.com//path/to/file#sha256=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-			"example.com/path/to/file/sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-		},
-		{
-			"https://example.com//path/to/file#2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-			"example.com/path/to/file/sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-		},
-		{
-			"https://example.com/path/to/file?a=1&b=2#7d793037a0760186574b0282f2f435e7",
+			"https://example.com/path/to/file?a=1&b=2#md5-7d793037a0760186574b0282f2f435e7",
 			"example.com/path/to/file" + url.PathEscape("?a=1&b=2") + "/md5-7d793037a0760186574b0282f2f435e7",
 		},
 	}
@@ -194,24 +182,24 @@ func Test_prepareHash(t *testing.T) {
 		wantInErr string
 	}{
 		{
-			"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-			crypto.SHA256,
-			"",
-		},
-		{
-			"sha256=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
-			crypto.SHA256,
-			"",
-		},
-		{
 			"sha256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
 			crypto.SHA256,
 			"",
 		},
 		{
+			"sha256-",
+			0,
+			"invalid fragment",
+		},
+		{
+			"-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			0,
+			"invalid fragment",
+		},
+		{
 			"deadbeef",
 			0,
-			"no supported hash",
+			"invalid fragment",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Supporting more adds a bit of complexity for probably no real gain.